### PR TITLE
Fix typo in slack_500.rb file exist check

### DIFF
--- a/lib/tasks/slack_500.rake
+++ b/lib/tasks/slack_500.rake
@@ -2,7 +2,7 @@ namespace :slack_500 do
   desc 'configuration slack_500'
   task :config do
     file = File.join(Rails.root,'config','initializers','slack_500.rb')
-    if File.exists?(file)
+    if File.exist?(file)
       puts "#{file} esxits. overwrite? (y/n)"
       s = STDIN.getc
       exit unless s[0].downcase == 'y'


### PR DESCRIPTION
exists? is no longer a valid method name for File:Class in Ruby 3